### PR TITLE
Removing hardware verification

### DIFF
--- a/qreader/src/main/java/github/nisrulz/qreader/QREader.java
+++ b/qreader/src/main/java/github/nisrulz/qreader/QREader.java
@@ -130,10 +130,6 @@ public class QREader {
       autoFocusEnabled = false;
     }
 
-    if (!hasCameraHardware(context)) {
-      Log.e(LOGTAG, "Does not have camera hardware!");
-      return;
-    }
     if (!checkCameraPermission(context)) {
       Log.e(LOGTAG, "Do not have camera permission!");
       return;


### PR DESCRIPTION
Some devices has problems to identify it own camera hardware and this validation may identify false positives

<!-- * Please fill out the blanks below describing your pull request * -->

**What does this implement/fix? Explain your changes**

**Does this close any currently open issues?**

**Any relevant logs, error output, bugreport etc?**
<!-- * If it’s long, please paste to https://ghostbin.com/ and insert the link here.) * -->

**Any other comments?**

+ **Where has this been tested?**

+ **Device Information:**

+ **Android Version:**

+ **Target Platform:**

+ **SDK Version:**

+ **Configuration Information:**

+ **Misc:** 

<!-- * More related information if you have can provide * -->